### PR TITLE
fix: rename execution phase properties in manifest

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -5,4 +5,4 @@ description=${project.description}
 class=io.gravitee.policy.messagefiltering.MessageFilteringPolicy
 type=policy
 category=others
-async=MESSAGE_REQUEST,MESSAGE_RESPONSE
+message=MESSAGE_REQUEST,MESSAGE_RESPONSE


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1708

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.1-apim1708-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-message-filtering/1.1.1-apim1708-SNAPSHOT/gravitee-policy-message-filtering-1.1.1-apim1708-SNAPSHOT.zip)
  <!-- Version placeholder end -->
