### PR TITLE
fix: properly ack message when there are filtered

### DIFF
--- a/src/main/java/io/gravitee/policy/messagefiltering/configuration/MessageFilteringPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/messagefiltering/configuration/MessageFilteringPolicyConfiguration.java
@@ -32,7 +32,17 @@ import lombok.Setter;
 public class MessageFilteringPolicyConfiguration implements PolicyConfiguration {
 
     /**
-     * Filter to apply in order to filter messages
+     * Condition to apply in order to filter messages
      */
     private String filter;
+
+    /**
+     * Option to ack filtered message. The ack will notify the source of the message that it has been handled.
+     */
+    private boolean ackFilteredMessage = true;
+
+    /**
+     * Option to filter message when an error occurs on applying filter on it
+     */
+    private boolean filterMessageOnFilteringError = true;
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -5,8 +5,20 @@
     "properties": {
         "filter": {
             "title": "Filter condition",
-            "description": "The condition to apply to filter messages (supports EL).",
+            "description": "The condition to apply to filter messages (supports EL). If the message matches the filtering condition, it is returned, otherwise it is filtered.",
             "type": "string"
+        },
+        "ackFilteredMessage": {
+            "title": "Ack filtered message",
+            "description": "This option allows for acknowledging filtered messages. The acknowledgment will inform the message source that it has been successfully processed.",
+            "type": "boolean",
+            "default": true
+        },
+        "filterMessageOnFilteringError": {
+            "title": "Filter message when an error occurs on applying filter on it",
+            "description": "This option allows for filter message when an error occurs on applying filter on it, i.e. Spel syntaxe error.",
+            "type": "boolean",
+            "default": true
         }
     },
     "required": ["filter"]


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-6786

**Description**

This PR attemps to fix issue when a certain level of QoS is applied on the request and filtered messages require to be acknowledged.
  - add a new option to enable/disable this ack on filtered message (true by default)
  - add a new option to enable/disable filtering message on condition evaluation (true per default as it was the original behavior)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.4-fix-issue-with-qos-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-message-filtering/1.1.4-fix-issue-with-qos-SNAPSHOT/gravitee-policy-message-filtering-1.1.4-fix-issue-with-qos-SNAPSHOT.zip)
  <!-- Version placeholder end -->
